### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Wenqing Zong"]
 description = "Easy to use, pure Rust implementation of Silero VAD algorithm"
 keywords = ["vad", "silero"]
 license = "GPL-2.0"
-homepage = "https://github.com/WenqingZong/Silero_VAD"
+repository = "https://github.com/WenqingZong/Silero_VAD"
 
 [dependencies]
 anyhow = "1.0.86"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.